### PR TITLE
Update Flattr's share URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ https://facebook.com/sharer.php?app_id=123456789&u=https://example.com
 ```
 
 ## Flattr
-- URL: https://flattr.com/submit
+- URL: https://flattr.com/submit/auto
 - Documentation: http://developers.flattr.net/auto-submit/
 - Parameters: `user_id`, `url`, `title`, `content`, `description`, `language`, `tags`, `hidden`, `category`
 


### PR DESCRIPTION
Was previously incorrectly pointing to Facebook's share url